### PR TITLE
Made dynamic types available to use in multiselect #1

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,8 +27,7 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
-
-  List<String> selected = [];
+  List<dynamic> selected = [];
 
   @override
   Widget build(BuildContext context) {
@@ -37,16 +36,40 @@ class _HomeState extends State<Home> {
       child: Padding(
         padding: const EdgeInsets.all(20.0),
         child: DropDownMultiSelect(
-          onChanged: (List<String> x) {
-            setState(() {
-              selected =x;
-            });
+          onChanged: (List<dynamic> x) {
+            print(x);
           },
-          options: ['a' , 'b' , 'c' , 'd'],
+          options: [new TestClass("a", 1), new TestClass("b", 2), "c", "d"],
           selectedValues: selected,
           whenEmpty: 'Select Something',
         ),
       ),
     ));
   }
+}
+
+class TestClass {
+  final String caption;
+  final int value;
+
+  TestClass(this.caption, this.value);
+
+  @override
+  String toString() {
+    // TODO: implement toString
+    return this.caption;
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other is TestClass) {
+      return other.value == value;
+    }
+
+    return false;
+  }
+
+  @override
+  // TODO: implement hashCode
+  int get hashCode => super.hashCode;
 }

--- a/lib/multiselect.dart
+++ b/lib/multiselect.dart
@@ -40,13 +40,13 @@ class _SelectRow extends StatelessWidget {
 ///
 class DropDownMultiSelect extends StatefulWidget {
   /// The options form which a user can select
-  final List<String> options;
+  final List<dynamic> options;
 
   /// Selected Values
-  final List<String> selectedValues;
+  final List<dynamic> selectedValues;
 
   /// This function is called whenever a value changes
-  final Function(List<String>) onChanged;
+  final Function(List<dynamic>) onChanged;
 
   /// defines whether the field is dense
   final bool isDense;
@@ -61,10 +61,10 @@ class DropDownMultiSelect extends StatefulWidget {
   final String? whenEmpty;
 
   /// a function to build custom childern
-  final Widget Function(List<String> selectedValues)? childBuilder;
+  final Widget Function(List<dynamic> selectedValues)? childBuilder;
 
   /// a function to build custom menu items
-  final Widget Function(String option)? menuItembuilder;
+  final Widget Function(dynamic option)? menuItembuilder;
 
   const DropDownMultiSelect({
     Key? key,
@@ -97,12 +97,14 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
                           EdgeInsets.symmetric(vertical: 15, horizontal: 10),
                       child: Text(widget.selectedValues.length > 0
                           ? widget.selectedValues
-                              .reduce((a, b) => a + ' , ' + b)
+                              .reduce(
+                                  (a, b) => a.toString() + ' , ' + b.toString())
+                              .toString()
                           : widget.whenEmpty ?? '')),
                   alignment: Alignment.centerLeft)),
           Align(
             alignment: Alignment.centerLeft,
-            child: DropdownButtonFormField<String>(
+            child: DropdownButtonFormField<dynamic>(
               decoration: widget.decoration != null
                   ? widget.decoration
                   : InputDecoration(
@@ -130,7 +132,7 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
                               ? widget.menuItembuilder!(x)
                               : _SelectRow(
                                   selected: widget.selectedValues.contains(x),
-                                  text: x,
+                                  text: x.toString(),
                                   onChange: (isSelected) {
                                     if (isSelected) {
                                       var ns = widget.selectedValues;

--- a/lib/multiselect.dart
+++ b/lib/multiselect.dart
@@ -157,6 +157,7 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
                             ns.add(x);
                             widget.onChanged(ns);
                           }
+                          _theState.notify();
                         },
                       ))
                   .toList(),


### PR DESCRIPTION
I changed the code so that you can use any object instead of strings only.

In order for this to work with your own classes you have to:
- Override toString
- Override hashCode and == operator

Maybe we could also add another function as a parameter for the widget, which gets the string representation of the objects instead of using toString?

Adds #1 