### PR TITLE
Fix selected values overlapping the label if label is provided in input decoration

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,14 +80,14 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   multiselect:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/multiselect.dart
+++ b/lib/multiselect.dart
@@ -67,6 +67,12 @@ class DropDownMultiSelect extends StatefulWidget {
   /// a function to build custom menu items
   final Widget Function(String option)? menuItembuilder;
 
+  /// a function to validate
+  final String Function(String? selectedOptions)? validator;
+
+  /// defines whether the widget is read-only
+  final bool readOnly;
+
   const DropDownMultiSelect({
     Key? key,
     required this.options,
@@ -78,6 +84,8 @@ class DropDownMultiSelect extends StatefulWidget {
     this.isDense = false,
     this.enabled = true,
     this.decoration,
+    this.validator,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -105,6 +113,7 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
           Align(
             alignment: Alignment.centerLeft,
             child: DropdownButtonFormField<String>(
+              validator: widget.validator != null ? widget.validator : null,
               decoration: widget.decoration != null
                   ? widget.decoration
                   : InputDecoration(
@@ -149,17 +158,19 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
                                 );
                         }),
                         value: x,
-                        onTap: () {
-                          if (widget.selectedValues.contains(x)) {
-                            var ns = widget.selectedValues;
-                            ns.remove(x);
-                            widget.onChanged(ns);
-                          } else {
-                            var ns = widget.selectedValues;
-                            ns.add(x);
-                            widget.onChanged(ns);
-                          }
-                        },
+                        onTap: !widget.readOnly
+                            ? () {
+                                if (widget.selectedValues.contains(x)) {
+                                  var ns = widget.selectedValues;
+                                  ns.remove(x);
+                                  widget.onChanged(ns);
+                                } else {
+                                  var ns = widget.selectedValues;
+                                  ns.add(x);
+                                  widget.onChanged(ns);
+                                }
+                              }
+                            : null,
                       ))
                   .toList(),
             ),

--- a/lib/multiselect.dart
+++ b/lib/multiselect.dart
@@ -18,6 +18,7 @@ class _SelectRow extends StatelessWidget {
       required this.selected,
       required this.text})
       : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -78,6 +79,7 @@ class DropDownMultiSelect extends StatefulWidget {
     this.enabled = true,
     this.decoration,
   }) : super(key: key);
+
   @override
   _DropDownMultiSelectState createState() => _DropDownMultiSelectState();
 }
@@ -115,7 +117,9 @@ class _DropDownMultiSelectState extends State<DropDownMultiSelect> {
                     ),
               isDense: true,
               onChanged: widget.enabled ? (x) {} : null,
-              value: null,
+              value: widget.selectedValues.length > 0
+                  ? widget.selectedValues[0]
+                  : null,
               selectedItemBuilder: (context) {
                 return widget.options
                     .map((e) => DropdownMenuItem(


### PR DESCRIPTION
Steps to reproduce: 

1. Implement example
2. Pass `InputDecorator` with `label` field to `DropDownMultiSelect` widget
3. Select items from dropdown
4. Save the dropdown selected values
5. Reload the screen 
6. Notice the `label` is overlapping with the selected values string. 

## The Fix
We pass the first element to the `value` of `DropdownButtonFormField` when there is at least one selected item, otherwise, we send null. 

This makes the widget render the label as the title of the widget and leaves space for the text widget in the stack to render the selected list.