### PR TITLE
fix "A RenderFlex overflowed error"

### DIFF
--- a/lib/multiselect.dart
+++ b/lib/multiselect.dart
@@ -26,19 +26,22 @@ class _SelectRow extends StatelessWidget {
         onChange(!selected);
         _theState.notify();
       },
-      child: Container(
-        height: kMinInteractiveDimension,
-        child: Row(
-          children: [
-            Checkbox(
-                value: selected,
-                onChanged: (x) {
-                  onChange(x!);
-                  _theState.notify();
-                }),
-            Text(text)
-          ],
-        ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Checkbox(
+              value: selected,
+              onChanged: (x) {
+                onChange(x!);
+                _theState.notify();
+              }),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: Text(text),
+            ),
+          )
+        ],
       ),
     );
   }


### PR DESCRIPTION
fix "A RenderFlex overflowed error" when value is long text 